### PR TITLE
thanks.php: Fix sizeof(): Parameter must be an array or an object tha…

### DIFF
--- a/gfksx/ThanksForPosts/notification/thanks.php
+++ b/gfksx/ThanksForPosts/notification/thanks.php
@@ -106,7 +106,7 @@ class thanks extends \phpbb\notification\type\base
 	public function get_avatar()
 	{
 		$thankers = $this->get_data('thankers');
-		return (sizeof($thankers) == 1) && $this->user_loader ? $this->user_loader->get_avatar($thankers[0]['user_id']) : '';
+		return (strlen($thankers) == 1) && $this->user_loader ? $this->user_loader->get_avatar($thankers[0]['user_id']) : '';
 	}
 
 	/**


### PR DESCRIPTION
…t implements Countable warning

Fixes:
[phpBB Debug] PHP Warning: in file [ROOT]/ext/gfksx/ThanksForPosts/notification/thanks.php on line 109: sizeof(): Parameter must be an array or an object that implements Countable