### PR TITLE
Fix JOIN in `helper::get_post_row()`

### DIFF
--- a/naguissa/thanksforposts/core/helper.php
+++ b/naguissa/thanksforposts/core/helper.php
@@ -950,7 +950,7 @@ class helper
 		$sql_array = array(
 			'SELECT' => 'p.*, u.username, u.username_clean, u.user_colour',
 			'FROM' => array($this->posts_table => 'p', $this->users_table => 'u'),
-			'WHERE' => 'p.post_id =' . (int) $post_id
+			'WHERE' => 'u.user_id = p.poster_id AND p.post_id =' . (int) $post_id
 		);
 		$sql = $this->db->sql_build_query('SELECT', $sql_array);
 		$result = $this->db->sql_query($sql);


### PR DESCRIPTION
Lack of `user_id` condition in WHERE created a JOIN with all users in database, which resulted memory errors on PHP level.